### PR TITLE
Get away from master-slave language

### DIFF
--- a/docsite/conf.py
+++ b/docsite/conf.py
@@ -50,8 +50,8 @@ templates_path = ['.templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General substitutions.
 project = 'Ansible Documentation'

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1791,16 +1791,16 @@ class LinuxNetwork(Network):
                     interfaces[device]['stp'] = get_file_content(os.path.join(path, 'bridge', 'stp_state')) == '1'
             if os.path.exists(os.path.join(path, 'bonding')):
                 interfaces[device]['type'] = 'bonding'
-                interfaces[device]['slaves'] = get_file_content(os.path.join(path, 'bonding', 'slaves'), default='').split()
+                interfaces[device]['subordinates'] = get_file_content(os.path.join(path, 'bonding', 'subordinates'), default='').split()
                 interfaces[device]['mode'] = get_file_content(os.path.join(path, 'bonding', 'mode'), default='').split()[0]
                 interfaces[device]['miimon'] = get_file_content(os.path.join(path, 'bonding', 'miimon'), default='').split()[0]
                 interfaces[device]['lacp_rate'] = get_file_content(os.path.join(path, 'bonding', 'lacp_rate'), default='').split()[0]
                 primary = get_file_content(os.path.join(path, 'bonding', 'primary'))
                 if primary:
                     interfaces[device]['primary'] = primary
-                    path = os.path.join(path, 'bonding', 'all_slaves_active')
+                    path = os.path.join(path, 'bonding', 'all_subordinates_active')
                     if os.path.exists(path):
-                        interfaces[device]['all_slaves_active'] = get_file_content(path) == '1'
+                        interfaces[device]['all_subordinates_active'] = get_file_content(path) == '1'
 
             # Check whether an interface is in promiscuous mode
             if os.path.exists(os.path.join(path,'flags')):

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -714,7 +714,7 @@ class Runner(object):
             "ansible_ssh_user": "apps",
             "defaults": {},
             "groups": {
-                "master1": [
+                "main1": [
                     "10.201.43.174"
                 ],
                 "all": [
@@ -723,7 +723,7 @@ class Runner(object):
                     "10.201.43.175",
                     "10.201.51.190"
                 ],
-                "slave": [
+                "subordinate": [
                     "10.201.43.175"
                 ],
                 "ungrouped": [
@@ -733,7 +733,7 @@ class Runner(object):
                     "10.201.43.174",
                     "10.201.43.175"
                 ],
-                "master": [
+                "main": [
                     "10.201.43.174"
                 ],
                 "test": [

--- a/lib/ansible/runner/action_plugins/set_fact.py
+++ b/lib/ansible/runner/action_plugins/set_fact.py
@@ -26,7 +26,7 @@ class ActionModule(object):
         self.runner = runner
 
     def run(self, conn, tmp, module_name, module_args, inject, complex_args=None, **kwargs):
-        ''' handler for running operations on master '''
+        ''' handler for running operations on main '''
 
         # load up options
         options  = {}

--- a/lib/ansible/runner/connection_plugins/ssh.py
+++ b/lib/ansible/runner/connection_plugins/ssh.py
@@ -67,7 +67,7 @@ class Connection(object):
             # make sure there is no empty string added as this can produce weird errors
             self.common_args += [x.strip() for x in shlex.split(extra_args) if x.strip()]
         else:
-            self.common_args += ["-o", "ControlMaster=auto",
+            self.common_args += ["-o", "ControlMain=auto",
                                  "-o", "ControlPersist=60s",
                                  "-o", "ControlPath=\"%s\"" % (C.ANSIBLE_SSH_CONTROL_PATH % dict(directory=self.cp_dir))]
 
@@ -114,11 +114,11 @@ class Connection(object):
             # try to use upseudo-pty
             try:
                 # Make sure stdin is a proper (pseudo) pty to avoid: tcgetattr errors
-                master, slave = pty.openpty()
-                p = subprocess.Popen(cmd, stdin=slave,
+                main, subordinate = pty.openpty()
+                p = subprocess.Popen(cmd, stdin=subordinate,
                                      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                stdin = os.fdopen(master, 'w', 0)
-                os.close(slave)
+                stdin = os.fdopen(main, 'w', 0)
+                os.close(subordinate)
             except:
                 p = subprocess.Popen(cmd, stdin=subprocess.PIPE,
                                      stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -147,7 +147,7 @@ class Connection(object):
     def _communicate(self, p, stdin, indata, sudoable=False, prompt=None):
         fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
         fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
-        # We can't use p.communicate here because the ControlMaster may have stdout open as well
+        # We can't use p.communicate here because the ControlMain may have stdout open as well
         stdout = ''
         stderr = ''
         rpipes = [p.stdout, p.stderr]

--- a/lib/ansible/utils/__init__.py
+++ b/lib/ansible/utils/__init__.py
@@ -400,7 +400,7 @@ def role_spec_parse(role_spec):
   
     role_spec = role_spec.strip()
     role_version = ''
-    default_role_versions = dict(git='master', hg='tip')
+    default_role_versions = dict(git='main', hg='tip')
     if role_spec == "" or role_spec.startswith("#"):
         return (None, None, None, None)
 

--- a/plugins/inventory/consul_io.py
+++ b/plugins/inventory/consul_io.py
@@ -70,8 +70,8 @@ if this is not set
 'tags':
 
 boolean flag defining if service tags should be used to create Inventory
-groups e.g. an nginx service with the tags ['master', 'v1'] will create
-groups nginx_master and nginx_v1 to which the node running the service
+groups e.g. an nginx service with the tags ['main', 'v1'] will create
+groups nginx_main and nginx_v1 to which the node running the service
 will be added. No tag groups are created if this is missing.
 
 'token':
@@ -273,7 +273,7 @@ class ConsulInventory(object):
 
   def extract_groups_from_tags(self, service_name, service, node_data):
     '''iterates each service tag and adds the node to groups derived from the
-    service and tag names e.g. nginx_master'''
+    service and tag names e.g. nginx_main'''
     if self.config.has_config('tags') and service['Tags']:
       tags = service['Tags']
       self.add_metadata(node_data, "consul_%s_tags" % service_name, tags)

--- a/test/units/TestUtils.py
+++ b/test/units/TestUtils.py
@@ -835,7 +835,7 @@ class TestUtils(unittest.TestCase):
                 {
                     'scm' : 'git',
                     'src' : 'http://github.com/ansible/fakerole/fake',
-                    'version' : 'master', 
+                    'version' : 'main', 
                     'name' : 'fake'
                 }
             ),
@@ -846,7 +846,7 @@ class TestUtils(unittest.TestCase):
                     'scm' : None,
                     'src' : 'http://github.com/ansible/fakerole/fake/archive/master.tar.gz',
                     'version' : '', 
-                    'name' : 'master'
+                    'name' : 'main'
                 }
             )
             ]


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.